### PR TITLE
Satellizer setup via config

### DIFF
--- a/src/js/authentication/controllers/provider-controller.js
+++ b/src/js/authentication/controllers/provider-controller.js
@@ -7,12 +7,6 @@ angular.module('app.modules.authentication.controllers').controller('ProviderCon
   function($scope, $auth, sat, $config, $notification) {
     'use strict';
 
-    if ($config.facebook) {
-      sat.facebook({
-        clientId: $config.facebook.clientId
-      });
-    }
-
     $scope.link = function(provider, next) {
       $auth.link(provider).then(function() {
         $notification.success('You have successfully linked ' + provider + ' account');

--- a/src/js/authentication/index.js
+++ b/src/js/authentication/index.js
@@ -4,6 +4,7 @@ angular.module('app.modules.authentication.directives', []);
 angular.module('app.modules.authentication', [
   'ui.router',
   'satellizer',
+  'app.services', // This currently relies on gulp task creating a config.js file
   'app.modules.common.services',
   'app.modules.alert',
   'app.modules.authentication.services',
@@ -11,7 +12,14 @@ angular.module('app.modules.authentication', [
   'app.modules.authentication.directives'
 ]).config([
   '$authProvider',
-  function($authProvider) {
+  '$configProvider',
+  function($authProvider, $configProvider) {
+    var $config = $configProvider.$get();
+
+    console.log($config);
+
+    configSatellizer($authProvider, $config.satellizer);
+
     $authProvider.tokenPrefix = 'auth';
   }
 ]).run([
@@ -127,3 +135,18 @@ angular.module('app.modules.authentication', [
     });
   }
 ]);
+
+/**
+ * Configure satillizer settings for available providers
+ * @param {object} $authProvider
+ * @param {object} $providers
+ */
+function configSatellizer($authProvider, $providers) {
+  if ($providers) {
+    for (var provider in $providers) {
+      if ($authProvider.hasOwnProperty(provider) && 'function' === typeof($authProvider[provider])) {
+        $authProvider[provider]($providers[provider]);
+      }
+    }
+  }
+}

--- a/src/js/authentication/index.js
+++ b/src/js/authentication/index.js
@@ -16,8 +16,6 @@ angular.module('app.modules.authentication', [
   function($authProvider, $configProvider) {
     var $config = $configProvider.$get();
 
-    console.log($config);
-
     configSatellizer($authProvider, $config.satellizer);
 
     $authProvider.tokenPrefix = 'auth';


### PR DESCRIPTION
This adds the ability to setup satellizer via config, only downside for now is that the config needs to be provided via `app.service`. This can probably be modified in future revisions for better modularity.